### PR TITLE
fix: correct LGTM users list formatting

### DIFF
--- a/code/prow.py
+++ b/code/prow.py
@@ -158,7 +158,7 @@ def lgtm():
         API_URL = API_PULLS + "/reviews"
         data = {
             "event": LGTM_REVIEW_EVENT,
-            "body": f"Approved by {valid_votes} LGTM votes. Users {lgtm_users.keys()}",
+            "body": f"Approved by {valid_votes} LGTM votes. Users {','.join(lgtm_users.keys())}",
         }
         print("✅ PR approved with LGTM votes.")
         make_request("POST", API_URL, data)

--- a/pipeline-prow.yaml
+++ b/pipeline-prow.yaml
@@ -222,7 +222,7 @@ spec:
                   API_URL = API_PULLS + "/reviews"
                   data = {
                       "event": LGTM_REVIEW_EVENT,
-                      "body": f"Approved by {valid_votes} LGTM votes. Users {lgtm_users.keys()}",
+                      "body": f"Approved by {valid_votes} LGTM votes. Users {','.join(lgtm_users.keys())}",
                   }
                   print("✅ PR approved with LGTM votes.")
                   make_request("POST", API_URL, data)


### PR DESCRIPTION
The LGTM users list in the approval message was incorrectly formatted as a
dictionary keys view. This change updates the formatting to a comma-separated
string of user names, ensuring the message is clear and readable.
