### PR TITLE
feat(prow): add rebase command support

### DIFF
--- a/.tekton/prow.yaml
+++ b/.tekton/prow.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prow-commands
   annotations:
     pipelinesascode.tekton.dev/pipeline: "./hack/pipeline-embedded-prow.yaml"
-    pipelinesascode.tekton.dev/on-comment: "^/(merge|help|lgtm|(assign|unassign|label|unlabel)[ ].*)$"
+    pipelinesascode.tekton.dev/on-comment: "^/(rebase|merge|help|lgtm|(assign|unassign|label|unlabel)[ ].*)$"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following commands are supported:
 | `/unlabel bug feature`  | Removes labels from the PR                                       |
 | `/lgtm`                 | Approves the PR if at least 1 org members have commented `/lgtm` |
 | `/merge`                | Merges the PR if it has enough `/lgtm` approvals                 |
-| `/rebase`                   | Rebases the PR branch on the base branch                                        |
+| `/rebase`               | Rebases the PR branch on the base branch                         |
 | `/help`                 | Shows this help message                                          |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following commands are supported:
 | `/unlabel bug feature`  | Removes labels from the PR                                       |
 | `/lgtm`                 | Approves the PR if at least 1 org members have commented `/lgtm` |
 | `/merge`                | Merges the PR if it has enough `/lgtm` approvals                 |
+| `/rebase`                   | Rebases the PR branch on the base branch                                        |
 | `/help`                 | Shows this help message                                          |
 
 ## Usage
@@ -31,7 +32,7 @@ metadata:
   name: prow-commands
   annotations:
     pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code-prow/refs/heads/main/pipeline-prow.yaml"
-    pipelinesascode.tekton.dev/on-comment: "^/(help|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$"
+    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:

--- a/hack/pipeline-embedded-prow.yaml
+++ b/hack/pipeline-embedded-prow.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prow-commands
   annotations:
     pipelinesascode.tekton.dev/on-comment: |
-      ^/(help|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
+      ^/(help|rebase|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
     pipelinesascode.tekton.dev/max-keep-runs: '5'
 spec:
   params:
@@ -173,6 +173,7 @@ spec:
           | `/unlabel bug feature`      | Removes labels from the PR                                                      |
           | `/lgtm`                     | Approves the PR if at least {LGTM_THRESHOLD} org members have commented `/lgtm` |
           | `/merge`                    | Merges the PR if it has enough `/lgtm` approvals                                |
+          | `/rebase`                   | Rebases the PR branch on the base branch                                        |
           | `/help`                     | Shows this help message                                                         |
           """
 
@@ -359,6 +360,11 @@ spec:
                       return None, False
 
                   return permission, permission in self.lgtm_permissions
+
+              def rebase(self) -> requests.Response:
+                  endpoint = f"pulls/{self.pr_num}/update-branch"
+                  self.post_comment("✅ Rebased the PR branch on the base branch.")
+                  return self.api.put(endpoint, {})
 
               def lgtm(self, send_comment: bool = True) -> int:
                   """
@@ -675,7 +681,7 @@ spec:
               pr_handler = PRHandler(api, args)
 
               match = re.match(
-                  r"^/(merge|assign|unassign|label|unlabel|lgtm|help)\s*(.*)",
+                  r"^/(rebase|merge|assign|unassign|label|unlabel|lgtm|help)\s*(.*)",
                   args.trigger_comment,
               )
               if not match:
@@ -700,6 +706,8 @@ spec:
                   pr_handler.unlabel(values)
               elif command == "lgtm":
                   pr_handler.lgtm()
+              elif command == "rebase":
+                  pr_handler.rebase()
               elif command == "merge":
                   pr_handler.merge_pr()
               elif command == "help":

--- a/hack/pipeline-embedded-prow.yaml
+++ b/hack/pipeline-embedded-prow.yaml
@@ -275,6 +275,15 @@ spec:
 
                   self._pr_status = None
 
+              def check_response(self, resp: requests.Response) -> bool:
+                  if resp.status_code > 200 and resp.status_code < 300:
+                      return True
+                  print(
+                      f"Error while executing the command: status: {resp.status_code} {resp.text}",
+                      file=sys.stderr,
+                  )
+                  return False
+
               def post_comment(self, message: str) -> requests.Response:
                   """
                   Posts a comment to the pull request.
@@ -698,20 +707,25 @@ spec:
                   print(f"⚠️ PR #{args.pr_num} is not open.", file=sys.stderr)
                   sys.exit(1)
 
+              response = None
               if command in ("assign", "unassign"):
-                  pr_handler.assign_unassign(command, values)
+                  response = pr_handler.assign_unassign(command, values)
               elif command == "label":
-                  pr_handler.label(values)
+                  response = pr_handler.label(values)
               elif command == "unlabel":
-                  pr_handler.unlabel(values)
+                  response = pr_handler.unlabel(values)
+              elif command == "rebase":
+                  response = pr_handler.rebase()
+              elif command == "help":
+                  response = pr_handler.post_comment(HELP_TEXT.strip())
               elif command == "lgtm":
                   pr_handler.lgtm()
-              elif command == "rebase":
-                  pr_handler.rebase()
               elif command == "merge":
                   pr_handler.merge_pr()
-              elif command == "help":
-                  pr_handler.post_comment(HELP_TEXT.strip())
+
+              if response:
+                  if not pr_handler.check_response(response):
+                      sys.exit(1)
 
 
           if __name__ == "__main__":

--- a/pipeline-prow.yaml
+++ b/pipeline-prow.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prow-commands
   annotations:
     pipelinesascode.tekton.dev/on-comment: |
-      ^/(help|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
+      ^/(help|rebase|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
     pipelinesascode.tekton.dev/max-keep-runs: '5'
 spec:
   params:

--- a/prow/base.yaml
+++ b/prow/base.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prow-commands
   annotations:
     pipelinesascode.tekton.dev/on-comment: |
-      ^/(help|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
+      ^/(help|rebase|merge|lgtm|(assign|unassign|label|unlabel)[ ].*)$
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/prow/prow.py
+++ b/prow/prow.py
@@ -108,6 +108,7 @@ HELP_TEXT = f"""
 | `/unlabel bug feature`      | Removes labels from the PR                                                      |
 | `/lgtm`                     | Approves the PR if at least {LGTM_THRESHOLD} org members have commented `/lgtm` |
 | `/merge`                    | Merges the PR if it has enough `/lgtm` approvals                                |
+| `/rebase`                   | Rebases the PR branch on the base branch                                        |
 | `/help`                     | Shows this help message                                                         |
 """
 
@@ -294,6 +295,11 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
             return None, False
 
         return permission, permission in self.lgtm_permissions
+
+    def rebase(self) -> requests.Response:
+        endpoint = f"pulls/{self.pr_num}/update-branch"
+        self.post_comment("✅ Rebased the PR branch on the base branch.")
+        return self.api.put(endpoint, {})
 
     def lgtm(self, send_comment: bool = True) -> int:
         """
@@ -610,7 +616,7 @@ def main():
     pr_handler = PRHandler(api, args)
 
     match = re.match(
-        r"^/(merge|assign|unassign|label|unlabel|lgtm|help)\s*(.*)",
+        r"^/(rebase|merge|assign|unassign|label|unlabel|lgtm|help)\s*(.*)",
         args.trigger_comment,
     )
     if not match:
@@ -635,6 +641,8 @@ def main():
         pr_handler.unlabel(values)
     elif command == "lgtm":
         pr_handler.lgtm()
+    elif command == "rebase":
+        pr_handler.rebase()
     elif command == "merge":
         pr_handler.merge_pr()
     elif command == "help":


### PR DESCRIPTION
Adds support for /rebase command to allow users to rebase their PR branch on
the base branch. This includes:

- Adding rebase command to regex patterns in tekton/prow.yaml
- Updating documentation in README.md to include /rebase command
- Adding rebase() method to PRHandler class in prow.py to handle rebase requests
- Adding rebase command to main command handler

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
