### PR TITLE
fix(prow.py): correct status code check in check_response method

### DIFF
--- a/hack/pipeline-embedded-prow.yaml
+++ b/hack/pipeline-embedded-prow.yaml
@@ -276,7 +276,7 @@ spec:
                   self._pr_status = None
 
               def check_response(self, resp: requests.Response) -> bool:
-                  if resp.status_code > 200 and resp.status_code < 300:
+                  if resp.status_code >= 200 and resp.status_code < 300:
                       return True
                   print(
                       f"Error while executing the command: status: {resp.status_code} {resp.text}",

--- a/prow/prow.py
+++ b/prow/prow.py
@@ -211,7 +211,7 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
         self._pr_status = None
 
     def check_response(self, resp: requests.Response) -> bool:
-        if resp.status_code > 200 and resp.status_code < 300:
+        if resp.status_code >= 200 and resp.status_code < 300:
             return True
         print(
             f"Error while executing the command: status: {resp.status_code} {resp.text}",


### PR DESCRIPTION
The status code check in the check_response method was updated to include 200 as a valid status code. The condition now correctly checks for status codes greater than or equal to 200 and less than 300.