### PR TITLE
refactor: improve cherry-pick conflict error message

### DIFF
--- a/pipelines_as_code_prow/messages.py
+++ b/pipelines_as_code_prow/messages.py
@@ -171,3 +171,32 @@ Successfully cherry-picked changes from PR #{source_pr} to branch `{target_branc
 * Cherry-picked by: @{user}
 * New commit SHA: `{commit_sha}`
 """
+
+CHERRY_PICK_CONFLICT = """
+🚨 Merge conflict detected while cherry-picking PR #{self.pr_num} to {target_branch}
+• Progress: {current_commit}/{total_commits} commits
+• Conflicting commit: {commit_sha}
+
+To resolve this conflict:
+1. Create a new branch from {target_branch}
+
+```shell
+git checkout -b resolve-cherry-pick-{self.pr_num} origin/{target_branch}
+```
+
+2. Cherry-pick the commits manually using:
+
+```shell
+git cherry-pick {commit_sha}
+```
+
+3. Resolve the conflicts with your favorite editor
+4. Create a new PR with your changes
+
+```shell
+git push YOURFORKREMOTE resolve-cherry-pick-{self.pr_num} --force-with-lease
+gh pr create --base {target_branch} --head YOURFORK:resolve-cherry-pick-{self.pr_num}
+```
+
+Need assistance? Please contact the repository maintainers.
+"""

--- a/pipelines_as_code_prow/prow.py
+++ b/pipelines_as_code_prow/prow.py
@@ -30,6 +30,7 @@ from .messages import (  # isort:skip
     SUCCESS_MERGED,
     CHERRY_PICK_ERROR,
     CHERRY_PICK_SUCCESS,
+    CHERRY_PICK_CONFLICT,
 )
 
 
@@ -554,21 +555,13 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
 
         Posts detailed information and instructions for manual resolution.
         """
-        conflict_message = f"""🚨 Merge conflict detected while cherry-picking PR #{self.pr_num} to {target_branch}
-• Progress: {current_commit}/{total_commits} commits
-• Conflicting commit: {commit_sha}
-
-To resolve this conflict:
-1. Create a new branch from {target_branch}
-2. Cherry-pick the commits manually using:
-```
-git checkout -b resolve-cherry-pick-{self.pr_num} {target_branch}
-git cherry-pick {commit_sha}
-```
-3. Resolve the conflicts
-4. Create a new PR with your changes
-
-Need assistance? Please contact the repository maintainers."""
+        conflict_message = CHERRY_PICK_CONFLICT.format(
+            pr_num=self.pr_num,
+            target_branch=target_branch,
+            current_commit=current_commit,
+            total_commits=total_commits,
+            commit_sha=commit_sha,
+        )
         self._post_comment(conflict_message)
 
 


### PR DESCRIPTION
Move the cherry-pick conflict message template to messages.py and enhance it with more detailed instructions. The new message provides clearer step-by-step guidance on how to resolve cherry-pick conflicts, including specific git commands for branching and creating PRs.